### PR TITLE
Update shadow-roles.md

### DIFF
--- a/mentoring/programs/shadow-roles.md
+++ b/mentoring/programs/shadow-roles.md
@@ -4,15 +4,16 @@ This area lists all of the shadow programs and how to get involved.
 Some areas are still in the process of forming shadow roles. 
 
 ## Release Team
-This SIG adheres to the Roles and Organization Management outlined in sig-governance and opts-in to updates and 
-modifications to sig-governance.
+This SIG release team is embedded within SIG Release and is responsible for the day to day work required to successfully release while the SIG at large is focused on the continued improvement of the release process.
+
+An overview of the release team can be found [here](https://github.com/kubernetes/sig-release/tree/master/release-team)
 
 The list of roles and duties can be found [here](https://github.com/kubernetes/sig-release/tree/master/release-team/role-handbooks)
 
 ## API Review
 
 ## Contributor Summit Planning
-The Content subteam of the events team is responsible for programming and content for periods of the contributor summit.
+The Content subteam creates in person and virtual experiences for new and current contributers to come learn, share and collaborate. 
 
 The list of roles and duties can be found [here](https://github.com/kubernetes/community/tree/master/events/events-team/content)
 


### PR DESCRIPTION
Updating shadow-roles.md to address missed comments in issue #4574

Some comments were not addressed for issue #4574 like:
- Update and add a description of the Release Team
- Add a link to an overview of the Release Team
- Adding a line to Contributor Summit Planning

@markyjackson-taulia @parispittman